### PR TITLE
Handle errors during CPU assignment

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -81,7 +81,11 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 		m.recorder.Eventf(ref, v1.EventTypeWarning, events.FailedToCreateContainer, "Failed to create container with error: %v", err)
 		return "Create Container Failed", err
 	}
-	m.cpuManager.RegisterContainer(pod, container, containerID)
+	err = m.cpuManager.RegisterContainer(pod, container, containerID)
+	if err != nil {
+		m.recorder.Eventf(ref, v1.EventTypeWarning, events.FailedToStartContainer, "Failed to register container with CPU manager: %v", err)
+		return "Registering With CPU Manager Failed", err
+	}
 	m.recorder.Eventf(ref, v1.EventTypeNormal, events.CreatedContainer, "Created container with id %v", containerID)
 	if ref != nil {
 		m.containerRefManager.SetRef(kubecontainer.ContainerID{


### PR DESCRIPTION
This patch adds a check that container has been registered successfully
in the cpu manager. There is a sizeable period of time before deleted
containers are actually removed and unregistered from cpu manager.
During this time k8s may assign new guaranteed containers to the node.
In this case registering new containers may fail due to lack of CPUs
(occupied by to-be-deleted containers) and new containers would not get
correct CPU settings.
With this patch such containers would be restarted until registration is
successful.
